### PR TITLE
Fixes to EmployeeDetails

### DIFF
--- a/HR_LEAVEv2/HR/EmployeeDetails.aspx
+++ b/HR_LEAVEv2/HR/EmployeeDetails.aspx
@@ -41,6 +41,13 @@
         <asp:Panel ID="validationRowPanel" runat="server" CssClass="row text-center" Style="margin-top: 25px;">
             <asp:UpdatePanel ID="UpdatePanel2" runat="server">
                 <ContentTemplate>
+                    <%--NO EDITS MADE---------------------------------------------------------------------------------------------%>
+                    <asp:Panel ID="noChangesMadePanel" runat="server" CssClass="emp-details-validation-msg" role="alert">
+                        <span class="alert alert-info">
+                            <i class="fa fa-info-circle" aria-hidden="true"></i>
+                            <span id="Span18" runat="server">No changes made</span>
+                        </span>
+                    </asp:Panel>
 
                     <%--SUCCESSES---------------------------------------------------------------------------------------------%>
 
@@ -57,7 +64,7 @@
                     <asp:Panel ID="editRolesSuccessPanel" runat="server" CssClass="emp-details-validation-msg" role="alert">
                         <span class="alert alert-success">
                             <i class="fa fa-thumbs-up" aria-hidden="true"></i>
-                            <span id="Span5" runat="server">Employee roles successfully edited</span>
+                            <span id="Span5" runat="server">Authorizations successfully edited</span>
                         </span>
                     </asp:Panel>
 
@@ -65,7 +72,7 @@
                      <asp:Panel ID="editLeaveSuccessPanel" runat="server" CssClass="emp-details-validation-msg" role="alert">
                         <span class="alert alert-success">
                             <i class="fa fa-thumbs-up" aria-hidden="true"></i>
-                            <span id="Span7" runat="server">Employee leave balances successfully edited</span>
+                            <span id="Span7" runat="server">Leave balances successfully edited</span>
                         </span>
                     </asp:Panel>
 
@@ -73,7 +80,7 @@
                      <asp:Panel ID="editEmpRecordSuccessPanel" runat="server" CssClass="emp-details-validation-msg" role="alert">
                         <span class="alert alert-success">
                             <i class="fa fa-thumbs-up" aria-hidden="true"></i>
-                            <span id="Span8" runat="server">Employee employment records successfully edited</span>
+                            <span id="Span8" runat="server">Employment record(s) successfully edited</span>
                         </span>
                     </asp:Panel>
 
@@ -102,7 +109,7 @@
                     <asp:Panel ID="editRolesErrorPanel" runat="server" CssClass="emp-details-validation-msg" role="alert">
                         <span class="alert alert-danger">
                             <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                            <span id="Span10" runat="server">Roles not edited</span>
+                            <span id="Span10" runat="server">Authorizations not edited</span>
                         </span>
                     </asp:Panel>
 
@@ -118,7 +125,7 @@
                     <asp:Panel ID="editEmpRecordErrorPanel" runat="server" CssClass="emp-details-validation-msg" role="alert">
                         <span class="alert alert-danger">
                             <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                            <span id="Span12" runat="server">Employment Record not edited</span>
+                            <span id="Span12" runat="server">Employment Record(s) not edited</span>
                         </span>
                     </asp:Panel>
 
@@ -432,6 +439,10 @@
                                 <asp:Panel ID="dateComparisonValidationMsgPanel" runat="server" CssClass="row alert alert-warning" Style="display: none; margin: 0px 5px;" role="alert">
                                     <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                                     <span id="dateComparisonValidationMsg" runat="server">End date cannot precede start date</span>
+                                </asp:Panel>
+                                <asp:Panel ID="duplicateRecordPanel" runat="server" CssClass="row alert alert-warning" Style="display: none; margin: 0px 5px;" role="alert">
+                                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                                    <span id="Span17" runat="server">Cannot add duplicate record</span>
                                 </asp:Panel>
                             </div>
                         </div>

--- a/HR_LEAVEv2/HR/EmployeeDetails.aspx.designer.cs
+++ b/HR_LEAVEv2/HR/EmployeeDetails.aspx.designer.cs
@@ -85,6 +85,24 @@ namespace HR_LEAVEv2.HR {
         protected global::System.Web.UI.UpdatePanel UpdatePanel2;
         
         /// <summary>
+        /// noChangesMadePanel control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel noChangesMadePanel;
+        
+        /// <summary>
+        /// Span18 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlGenericControl Span18;
+        
+        /// <summary>
         /// editFullSuccessPanel control.
         /// </summary>
         /// <remarks>
@@ -875,6 +893,24 @@ namespace HR_LEAVEv2.HR {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl dateComparisonValidationMsg;
+        
+        /// <summary>
+        /// duplicateRecordPanel control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel duplicateRecordPanel;
+        
+        /// <summary>
+        /// Span17 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlGenericControl Span17;
         
         /// <summary>
         /// cancelNewRecordBtn control.


### PR DESCRIPTION
1. Added more detailed error and success messaging to user after edit, this includes only showing which specific section they edited rather than general success messages
2. if no edits are made, an appropriate message is displayed
3. fixed issue whereby new records being added could not have their actual_end_date populated.
4. Changed flow of edit such that at the end of an edit, the page is then ready again for subsequent edits one time