### PR TITLE
Edit employee records

### DIFF
--- a/HR_LEAVEv2/Classes/Util.cs
+++ b/HR_LEAVEv2/Classes/Util.cs
@@ -27,6 +27,28 @@ namespace HR_LEAVEv2.Classes
             public string subject { get; set; }
         }
 
+
+        public string sanitizeStringForAsciiCharacters(string str)
+        {
+            // sanitize search strings for any ASCII characters that may cause trouble 
+            // single quote ('), double quote ("), open bracket and close bracket
+
+            // single quote
+            str = str.Replace("&#39;", "'");
+
+            //double quote
+            str = str.Replace("&#34;", "\"");
+
+            //open bracket
+            str = str.Replace("&#40;", "(");
+
+            //close bracket
+            str = str.Replace("&#41;", ")");
+
+            return str;
+
+        }
+
         public string resetNumNotifications(string employee_id)
         {
             /* What this function does:

--- a/HR_LEAVEv2/HR/EmployeeDetails.aspx
+++ b/HR_LEAVEv2/HR/EmployeeDetails.aspx
@@ -612,6 +612,8 @@
                             <asp:TemplateField HeaderText="Status">
                                 <ItemTemplate>
                                     <span id="status-label" class="label <%# Eval("status_class") %>"><%# Eval("status") %></span>
+                                    <asp:Label ID="new_record_label" runat="server" CssClass="label label-primary" Text="New" Visible ="false"></asp:Label>
+                                    <asp:Label ID="edited_record_label" runat="server" CssClass="label label-warning" Text="Edited" Visible ="false"></asp:Label>
                                 </ItemTemplate>
                             </asp:TemplateField>
 

--- a/HR_LEAVEv2/HR/EmployeeDetails.aspx
+++ b/HR_LEAVEv2/HR/EmployeeDetails.aspx
@@ -470,7 +470,15 @@
                                     <span id="Span22" runat="server">Actual end date is on the weekend</span>
                                 </asp:Panel>
 
-                                <asp:Panel ID="multipleActiveRecordsPanel" runat="server" CssClass="row alert alert-warning" Style="display: none; margin: 0px 5px;" role="alert">
+                                <asp:Panel ID="multipleActiveRecordsAddRecordPanel" runat="server" CssClass="row alert alert-warning" Style="display: none; margin: 0px 5px;" role="alert">
+                                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                                    <span id="Span25" runat="server">
+                                        Record not added since this would result in two employment records being marked active simultaneously. Edit employment records accordingly 
+                                        to ensure only one active record
+                                    </span>
+                                </asp:Panel>
+
+                                <asp:Panel ID="multipleActiveRecordsEditRecordPanel" runat="server" CssClass="row alert alert-warning" Style="display: none; margin: 0px 5px;" role="alert">
                                     <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                                     <span id="Span23" runat="server">
                                         Actual end date not edited since the date entered would result in two employment records being marked active simultaneously. Edit employment records accordingly 
@@ -594,11 +602,18 @@
                             <%--Index 7: Expected End Date--%>
                             <asp:BoundField HeaderText="Expected End Date" DataField="expected_end_date" DataFormatString="{0:d/MM/yyyy}"/>
 
-                            <%--Index 8: isDeleted--%>
+                            <%--Index 8: isChanged--%>
                             <asp:BoundField HeaderText="isChanged" DataField="isChanged" HeaderStyle-CssClass="hidden" ItemStyle-CssClass="hidden" />
 
                             <%--Index 9: actual_end_date--%>
                             <asp:BoundField HeaderText="Actual End Date" DataField="actual_end_date"/>
+
+                             <%--Index 10: status--%>
+                            <asp:TemplateField HeaderText="Status">
+                                <ItemTemplate>
+                                    <span id="status-label" class="label <%# Eval("status_class") %>"><%# Eval("status") %></span>
+                                </ItemTemplate>
+                            </asp:TemplateField>
 
                         </Columns>
                     </asp:GridView>

--- a/HR_LEAVEv2/HR/EmployeeDetails.aspx
+++ b/HR_LEAVEv2/HR/EmployeeDetails.aspx
@@ -13,9 +13,10 @@
             margin-bottom:25px;
         }
 
-        .new-record{
+        .highlighted-record{
             background-color: #e0e0eb;
         }
+
     </style>
 
     <asp:LinkButton ID="returnToPreviousBtn" runat="server" CssClass="btn btn-primary content-tooltipped" data-toggle="tooltip" data-placement="right" title="Return to all employees" OnClick="returnToPreviousBtn_Click">
@@ -377,7 +378,7 @@
             </div>
         </div>
 
-        <%--Add new Employment Record--%>
+        <%--Employment Record form--%>
         <div id="addEmploymentRecordContainer" class="container text-center" style="background-color: #f0f0f5; padding-bottom: 10px;">
             <h3>Employment Record</h3>
             <asp:UpdatePanel ID="UpdatePanel1" runat="server">
@@ -399,7 +400,7 @@
                                 <asp:SqlDataSource ID="SqlDataSource1" runat="server" ConnectionString="<%$ ConnectionStrings:dbConnectionString %>" ProviderName="System.Data.SqlClient" SelectCommand="SELECT [pos_id], [pos_name] FROM [position] ORDER BY [pos_name]"></asp:SqlDataSource>
                             </div>
                             <div class="form-group text-center" style="margin-top: 45px;">
-                                <span style="margin-right: 7%;">
+                                <span style="margin-right: 25px">
                                     <label for="txtStartDate">Start date</label>
                                     <asp:TextBox ID="txtStartDate" runat="server" CssClass="form-control" Style="width: 150px; display: inline;"></asp:TextBox>
                                     <i id="startDateCalendar" class="fa fa-calendar fa-lg calendar-icon"></i>
@@ -425,6 +426,14 @@
 
                                     </asp:RequiredFieldValidator>
                                 </span>
+                                <span runat="server" id="actualEndDateSpan" style="display:none; margin-left:25px;">
+                                    <label for="txtActualEndDate">
+                                        Actual end date
+                                    </label>
+                                    <asp:TextBox ID="txtActualEndDate" runat="server" CssClass="form-control" Style="width: 150px; display: inline;"></asp:TextBox>
+                                    <i id="actualEndDateCalendar" class="fa fa-calendar fa-lg calendar-icon"></i>
+                                    <ajaxToolkit:CalendarExtender ID="CalendarExtender3" TargetControlID="txtActualEndDate" PopupButtonID="actualEndDateCalendar" runat="server" Format="d/MM/yyyy"></ajaxToolkit:CalendarExtender>
+                                </span>
                             </div>
 
                             <div id="validationDiv" style="margin-top: 25px;">
@@ -434,11 +443,11 @@
                                 </asp:Panel>
                                 <asp:Panel ID="invalidEndDateValidationMsgPanel" runat="server" CssClass="row alert alert-warning" Style="display: none; margin: 0px 5px;" role="alert">
                                     <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                                    <span id="invalidEndDateValidationMsg" runat="server">End date is not valid</span>
+                                    <span id="invalidEndDateValidationMsg" runat="server">Expected end date is not valid</span>
                                 </asp:Panel>
                                 <asp:Panel ID="dateComparisonValidationMsgPanel" runat="server" CssClass="row alert alert-warning" Style="display: none; margin: 0px 5px;" role="alert">
                                     <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                                    <span id="dateComparisonValidationMsg" runat="server">End date cannot precede start date</span>
+                                    <span id="dateComparisonValidationMsg" runat="server">Expected end date cannot precede start date</span>
                                 </asp:Panel>
                                 <asp:Panel ID="startDateIsWeekendPanel" runat="server" CssClass="row alert alert-warning" Style="display: none; margin: 0px 5px;" role="alert">
                                     <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
@@ -452,6 +461,42 @@
                                     <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
                                     <span id="Span17" runat="server">Cannot add duplicate record</span>
                                 </asp:Panel>
+                                <asp:Panel ID="recordEditEndDateInvalidPanel" runat="server" CssClass="row alert alert-warning" Style="display: none; margin: 0px 5px;" role="alert">
+                                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                                    <span>Actual end date is not valid</span>
+                                </asp:Panel>
+                                <asp:Panel ID="recordEditEndDateOnWeekend" runat="server" CssClass="row alert alert-warning" Style="display: none; margin: 0px 5px;" role="alert">
+                                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                                    <span id="Span22" runat="server">Actual end date is on the weekend</span>
+                                </asp:Panel>
+
+                                <asp:Panel ID="multipleActiveRecordsPanel" runat="server" CssClass="row alert alert-warning" Style="display: none; margin: 0px 5px;" role="alert">
+                                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                                    <span id="Span23" runat="server">
+                                        Actual end date not edited since the date entered would result in two employment records being marked active simultaneously. Edit employment records accordingly 
+                                        to ensure only one active record
+                                    </span>
+                                </asp:Panel>
+
+                                <asp:Panel ID="recordEditEndDateBeforeStartDate" runat="server" CssClass="row alert alert-warning" Style="display: none; margin: 0px 5px;" role="alert">
+                                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                                    <span>Actual end date cannot be before start date</span>
+                                </asp:Panel>
+
+                                <asp:Panel ID="noEditsToRecordsMade" runat="server" CssClass="row alert alert-info" Style="display: none; margin: 0px 5px; margin-top:5px;" role="alert">
+                                    <i class="fa fa-info-circle" aria-hidden="true"></i>
+                                    <span>No Edits made</span>
+                                </asp:Panel>
+
+                                <asp:Panel ID="editUnsuccessful" runat="server" CssClass="row alert alert-danger" Style="display: none; margin: 0px 5px;" role="alert">
+                                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                                    <span>Edits could not be made</span>
+                                </asp:Panel>
+
+                                <asp:Panel ID="editEmploymentRecordSuccessful" runat="server" CssClass="row alert alert-success" Style="display: none; margin: 0px 5px; margin-top:5px;" role="alert">
+                                    <i class="fa fa-thumbs-up" aria-hidden="true"></i>
+                                    <span id="editEmpRecordSuccTxt" runat="server"></span>
+                                </asp:Panel>
                             </div>
                         </div>
                         <div class="text-center" style="margin-top: 35px; margin-bottom: 45px;">
@@ -462,6 +507,10 @@
                             <asp:LinkButton runat="server" ID="addNewRecordBtn" CssClass="btn btn-primary" Text="Add new Record" OnClick="addNewRecordBtn_Click" ValidationGroup="empRecord">
                                  <i class="fa fa-plus" aria-hidden="true"></i>
                                  Add new record
+                            </asp:LinkButton>
+                            <asp:LinkButton runat="server" ID="editRecordBtn" CssClass="btn btn-primary" Text="Edit new Record" OnClick="editRecordBtn_Click" ValidationGroup="empRecord" Visible="false">
+                                 <i class="fa fa-floppy-o" aria-hidden="true"></i>
+                                 Save record
                             </asp:LinkButton>
                         </div>
 
@@ -478,6 +527,20 @@
                         <Columns>
                             <asp:TemplateField HeaderText="Action" Visible="true">
                                 <ItemTemplate>
+                                    <%--edit emp record button--%>
+                                    <asp:LinkButton ID="LinkButton1"
+                                        runat="server"
+                                        CssClass="btn btn-warning content-tooltipped"
+                                        data-toggle="tooltip"
+                                        data-placement="bottom"
+                                        title="Edit employment record"
+                                        CausesValidation="false" 
+                                        CommandName="editEmpRecord"
+                                        CommandArgument =" <%# ((GridViewRow) Container).RowIndex %>"
+                                        >
+                                        <i class="fa fa fa-pencil" aria-hidden="true"></i>
+                                    </asp:LinkButton>
+
                                     <%--delete button--%>
                                     <asp:LinkButton ID="deleteBtn"
                                         runat="server"
@@ -559,8 +622,8 @@
 
         <asp:Panel ID="editFormPanel" runat="server" CssCclass="row text-center" Style="margin-top: 50px;">
             <asp:LinkButton ID="editBtn" CssClass="btn btn-success" runat="server" ValidationGroup="submitFullFormGroup" OnClick="editBtn_Click">
-                <i class="fa fa-pencil" aria-hidden="true"></i>
-                Edit employee
+                <i class="fa fa-floppy-o" aria-hidden="true"></i>
+                Save employee
             </asp:LinkButton>
         </asp:Panel>
     </div>
@@ -608,13 +671,21 @@
                                 <span>End date cannot be before start date</span>
                             </asp:Panel>
 
+                            <asp:Panel ID="multipleActiveRecordsEndRecordPanel" runat="server" CssClass="row alert alert-warning" Style="display: none; margin: 0px 5px;" role="alert">
+                                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                                <span id="Span24" runat="server">
+                                    Actual end date not edited since the date entered would result in two employment records being marked active simultaneously. Edit employment records accordingly 
+                                    to ensure only one active record
+                                </span>
+                            </asp:Panel>
+
                         </div>
                         <div class="modal-footer">
                             <asp:LinkButton runat="server" ID="submitEndEmpRecordBtn" class="btn btn-primary" OnClick="submitEndEmpRecordBtn_Click" CausesValidation="false">
                                  <i class="fa fa-send" aria-hidden="true"></i>
                                  Submit
                             </asp:LinkButton>
-                            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                            <asp:Button ID="closeEndEmpRecordModalBtn" runat="server" Text="Close" CssClass="btn btn-secondary" OnClick="closeEndEmpRecordModalBtn_Click"/>
                         </div>
                     </div>
                 </ContentTemplate>

--- a/HR_LEAVEv2/HR/EmployeeDetails.aspx.cs
+++ b/HR_LEAVEv2/HR/EmployeeDetails.aspx.cs
@@ -225,10 +225,7 @@ namespace HR_LEAVEv2.HR
             if (ViewState["frontend_record_being_edited"] != null)
             {
                 int index = Convert.ToInt32(ViewState["frontend_record_being_edited"].ToString());
-                if (GridView1.Rows[index].Cells[GetColumnIndexByName(GridView1.Rows[index], "record_id")].Text.ToString() != "-1")
-                {
-                    GridView1.Rows[index].CssClass = GridView1.Rows[index].CssClass.Replace("highlighted-record", "");
-                }
+                GridView1.Rows[index].CssClass = GridView1.Rows[index].CssClass.Replace("highlighted-record", "");
                 ViewState["frontend_record_being_edited"] = null;
                 ViewState["record_being_edited"] = null;
             }
@@ -285,7 +282,7 @@ namespace HR_LEAVEv2.HR
                 // case: cannot add another record if there already exists an active record
                 foreach(DataRow dr in dt.Rows)
                 {
-                    if(dr.ItemArray[(int)emp_records_columns.status].ToString() == "Active")
+                    if(dr.ItemArray[(int)emp_records_columns.isChanged].ToString() != "1" && dr.ItemArray[(int)emp_records_columns.status].ToString() == "Active")
                     {
                         multipleActiveRecordsAddRecordPanel.Style.Add("display", "inline-block");
                         isRecordAllowed = false;
@@ -330,6 +327,7 @@ namespace HR_LEAVEv2.HR
                     {
                         //record_id, employment_type, dept_id, dept_name, pos_id, pos_name, start_date, expected_end_date, isChanged, actual_end_date, status, status_class
                         dt.Rows.Add(-1, emp_type, dept_id, dept_name, position_id, position_name, DateTime.ParseExact(startDate, "d/MM/yyyy", System.Globalization.CultureInfo.InvariantCulture), expected_end_date, "0", "", "Active", "label-success");
+
 
                         ViewState["Gridview1_dataSource"] = dt;
                     }
@@ -1633,10 +1631,24 @@ namespace HR_LEAVEv2.HR
             if (e.Row.RowType == DataControlRowType.DataRow)
             {
 
-                // highlight new records
+                // adds badge to new records
                 i = GetColumnIndexByName(e.Row, "record_id");
-                if (e.Row.Cells[i].Text.ToString() == "-1" && this.isEditMode) // row is a new record if record_id = -1
-                    e.Row.CssClass = "highlighted-record";
+                if (e.Row.Cells[i].Text.ToString() == "-1" && this.isEditMode)
+                {
+                    // row is a new record if record_id = -1
+                    Label newRecordLabel = (Label)e.Row.FindControl("new_record_label");
+                    newRecordLabel.Visible = true;
+                }
+
+
+                // add badge to edited records
+                i = GetColumnIndexByName(e.Row, "isChanged");
+                if (e.Row.Cells[i].Text.ToString() == "2" && this.isEditMode)
+                {
+                    // row is an edited record if isChanged = 2
+                    Label editedRecordLabel = (Label)e.Row.FindControl("edited_record_label");
+                    editedRecordLabel.Visible = true;
+                }
 
                 //hide end employment record button if actual_end_date is already populated
                 i = GetColumnIndexByName(e.Row, "actual_end_date");

--- a/HR_LEAVEv2/HR/EmployeeDetails.aspx.designer.cs
+++ b/HR_LEAVEv2/HR/EmployeeDetails.aspx.designer.cs
@@ -1012,13 +1012,31 @@ namespace HR_LEAVEv2.HR {
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl Span22;
         
         /// <summary>
-        /// multipleActiveRecordsPanel control.
+        /// multipleActiveRecordsAddRecordPanel control.
         /// </summary>
         /// <remarks>
         /// Auto-generated field.
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
-        protected global::System.Web.UI.WebControls.Panel multipleActiveRecordsPanel;
+        protected global::System.Web.UI.WebControls.Panel multipleActiveRecordsAddRecordPanel;
+        
+        /// <summary>
+        /// Span25 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlGenericControl Span25;
+        
+        /// <summary>
+        /// multipleActiveRecordsEditRecordPanel control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel multipleActiveRecordsEditRecordPanel;
         
         /// <summary>
         /// Span23 control.

--- a/HR_LEAVEv2/HR/EmployeeDetails.aspx.designer.cs
+++ b/HR_LEAVEv2/HR/EmployeeDetails.aspx.designer.cs
@@ -850,6 +850,33 @@ namespace HR_LEAVEv2.HR {
         protected global::System.Web.UI.WebControls.RequiredFieldValidator endDateRequiredValidator;
         
         /// <summary>
+        /// actualEndDateSpan control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlGenericControl actualEndDateSpan;
+        
+        /// <summary>
+        /// txtActualEndDate control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.TextBox txtActualEndDate;
+        
+        /// <summary>
+        /// CalendarExtender3 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::AjaxControlToolkit.CalendarExtender CalendarExtender3;
+        
+        /// <summary>
         /// invalidStartDateValidationMsgPanel control.
         /// </summary>
         /// <remarks>
@@ -958,6 +985,96 @@ namespace HR_LEAVEv2.HR {
         protected global::System.Web.UI.HtmlControls.HtmlGenericControl Span17;
         
         /// <summary>
+        /// recordEditEndDateInvalidPanel control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel recordEditEndDateInvalidPanel;
+        
+        /// <summary>
+        /// recordEditEndDateOnWeekend control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel recordEditEndDateOnWeekend;
+        
+        /// <summary>
+        /// Span22 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlGenericControl Span22;
+        
+        /// <summary>
+        /// multipleActiveRecordsPanel control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel multipleActiveRecordsPanel;
+        
+        /// <summary>
+        /// Span23 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlGenericControl Span23;
+        
+        /// <summary>
+        /// recordEditEndDateBeforeStartDate control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel recordEditEndDateBeforeStartDate;
+        
+        /// <summary>
+        /// noEditsToRecordsMade control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel noEditsToRecordsMade;
+        
+        /// <summary>
+        /// editUnsuccessful control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel editUnsuccessful;
+        
+        /// <summary>
+        /// editEmploymentRecordSuccessful control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel editEmploymentRecordSuccessful;
+        
+        /// <summary>
+        /// editEmpRecordSuccTxt control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlGenericControl editEmpRecordSuccTxt;
+        
+        /// <summary>
         /// cancelNewRecordBtn control.
         /// </summary>
         /// <remarks>
@@ -974,6 +1091,15 @@ namespace HR_LEAVEv2.HR {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.LinkButton addNewRecordBtn;
+        
+        /// <summary>
+        /// editRecordBtn control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.LinkButton editRecordBtn;
         
         /// <summary>
         /// GridView1 control.
@@ -1111,6 +1237,24 @@ namespace HR_LEAVEv2.HR {
         protected global::System.Web.UI.WebControls.Panel endDateBeforeStartDatePanel;
         
         /// <summary>
+        /// multipleActiveRecordsEndRecordPanel control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Panel multipleActiveRecordsEndRecordPanel;
+        
+        /// <summary>
+        /// Span24 control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.HtmlControls.HtmlGenericControl Span24;
+        
+        /// <summary>
         /// submitEndEmpRecordBtn control.
         /// </summary>
         /// <remarks>
@@ -1118,5 +1262,14 @@ namespace HR_LEAVEv2.HR {
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.LinkButton submitEndEmpRecordBtn;
+        
+        /// <summary>
+        /// closeEndEmpRecordModalBtn control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Button closeEndEmpRecordModalBtn;
     }
 }

--- a/HR_LEAVEv2/UserControls/MainGridView.ascx
+++ b/HR_LEAVEv2/UserControls/MainGridView.ascx
@@ -197,7 +197,7 @@
                     <i class="fa fa-check" aria-hidden="true"></i>
                     </asp:LinkButton>
 
-                    <asp:LinkButton ID="btnEditLeaveRequest" CssClass="btn btn-primary content-tooltipped" data-toggle="tooltip" data-placement="top" title="Edit Leave Request" Visible="<%# btnSupVisible || btnHrVisible %>" runat="server"
+                    <asp:LinkButton ID="btnEditLeaveRequest"  CssClass="btn btn-warning content-tooltipped" data-toggle="tooltip" data-placement="top" title="Edit Leave Request" Visible="<%# btnSupVisible || btnHrVisible %>" runat="server"
                         CommandName="editLeaveRequest"
                         CommandArgument="<%# ((GridViewRow) Container).RowIndex %>">
                     <i class="fa fa-pencil" aria-hidden="true"></i>


### PR DESCRIPTION
**Edit Employee records**
---
*The Problem*
HR requested the functionality of being able to edit employment records. This further brought up issues with consistency across the system whereby editing the actual end date could result in more than one employment record being active at a given time.

*Issues fixed*
- added edit option to employment records
- added validation to every form where actual end date could be edited/added
  - added validation to edit option that checks whether an edit (to actual end date) would result in more than one active record
  - added validation to end record option 
- Added badges to employment records which show whether a record is:
  - Active/ Inactive
  - New
  - Edited