### PR TITLE
Fixed employee details modal:

### DIFF
--- a/HR_LEAVEv2/HR/AllEmployees.aspx
+++ b/HR_LEAVEv2/HR/AllEmployees.aspx
@@ -270,24 +270,11 @@
 
                             <h3>Leave Balances</h3>
 
-                            <div>
-                                <h4 style="display: inline">Vacation Leave Balance:</h4>
-                                <span id="vacationDetails"></span>
-                            </div>
+                            <div id="leaveBalancesDetails"></div>
 
-                            <div>
-                                <h4 style="display: inline">Personal Leave Balance:</h4>
-                                <span id="personalDetails"></span>
-                            </div>
-
-                            <div>
-                                <h4 style="display: inline">Casual Leave Balance:</h4>
-                                <span id="casualDetails"></span>
-                            </div>
-
-                            <div>
-                                <h4 style="display: inline">Sick Leave Balance:</h4>
-                                <span id="sickDetails"></span>
+                            <div id="leaveBalancesErrorPanel" class="alert alert-info" style="margin: 5px 0px; display: inline-block; font-size: 0.90em">
+                                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                                <span>Leave balances could not be loaded</span>
                             </div>
                         </div>
                         <div class="modal-footer">
@@ -355,19 +342,19 @@
             $('#empIdDetails').text(data.emp_id);
             $('#ihrisIdDetails').text(data.ihris_id);
             $('#emailDetails').text(data.email);
-            $('#vacationDetails').text(data.vacation);
-            $('#personalDetails').text(data.personal);
-            $('#casualDetails').text(data.casual);
-            $('#sickDetails').text(data.sick);
+            $('#leaveBalancesDetails').html(data.leave_balances);
             if (data.isCompleteRecord == '1') {
                 $('#errorPanel').hide();
-                $('#positionDetails').show();
+                $('#leaveBalancesErrorPanel').hide();
 
-                $('#empTypeDetails').text(data.employment_type);
+                $('#positionDetails').show();
                 $('#empPositionDetails').text(data.position);
+
+                $('#empTypeDetails').text(data.employment_type);            
             } else {
                 $('#positionDetails').hide();
                 $('#errorPanel').show();
+                $('#leaveBalancesErrorPanel').show();
             }
 
         }

--- a/HR_LEAVEv2/HR/AllEmployees.aspx.cs
+++ b/HR_LEAVEv2/HR/AllEmployees.aspx.cs
@@ -23,7 +23,8 @@ namespace HR_LEAVEv2.HR
             public string personal { get; set; }
             public string casual { get; set; }
             public string sick { get; set; }
-
+            public string leave_balances { get; set; }
+            public DateTime start_date { get; set; }
             public string employment_type { get; set; }
             public string position { get; set; }
         };
@@ -320,15 +321,17 @@ namespace HR_LEAVEv2.HR
             try
             {
                 string sql = $@"
-                        SELECT TOP 1 e.employee_id, e.ihris_id, e.first_name + ' ' + e.last_name as 'Name', e.email,e.vacation,e.personal, e.casual, e.sick, ep.employment_type, p.pos_name
+                        SELECT TOP 1 e.employee_id, e.ihris_id, e.first_name + ' ' + e.last_name as 'Name', e.email,e.vacation,e.personal, e.casual, e.sick, ep.employment_type, ep.start_date, p.pos_name
                         FROM [dbo].[employee] e
+
                         RIGHT JOIN [dbo].employeeposition ep
                         ON e.employee_id = ep.employee_id
 
                         INNER JOIN [dbo].position p
                         ON ep.position_id = p.pos_id
+
                         WHERE e.employee_id = {emp_id}
-                        ORDER BY ep.start_date DESC;
+                        ORDER BY ISNULL(ep.actual_end_date, CAST('1/1/9999' AS DATE)) DESC;
                     ";
 
                 using (SqlConnection connection = new SqlConnection(ConfigurationManager.ConnectionStrings["dbConnectionString"].ConnectionString))
@@ -338,23 +341,77 @@ namespace HR_LEAVEv2.HR
                     {
                         using (SqlDataReader reader = command.ExecuteReader())
                         {
-                            while (reader.Read())
+                            if (reader.HasRows)
                             {
-                                empDetails = new EmpDetails
+                                while (reader.Read())
                                 {
-                                    emp_id = reader["employee_id"].ToString(),
-                                    ihris_id = reader["ihris_id"].ToString(),
-                                    name = reader["name"].ToString(),
-                                    email = reader["email"].ToString(),
-                                    vacation = reader["vacation"].ToString(),
-                                    personal = reader["personal"].ToString(),
-                                    casual = reader["casual"].ToString(),
-                                    sick = reader["sick"].ToString(),
-                                    employment_type = reader["employment_type"].ToString(),
-                                    position = reader["pos_name"].ToString(),
-                                    isCompleteRecord = '1'   
-                                };
-                            }
+                                    empDetails = new EmpDetails
+                                    {
+                                        emp_id = reader["employee_id"].ToString(),
+                                        ihris_id = reader["ihris_id"].ToString(),
+                                        name = reader["name"].ToString(),
+                                        email = reader["email"].ToString(),
+                                        vacation = reader["vacation"].ToString(),
+                                        personal = reader["personal"].ToString(),
+                                        casual = reader["casual"].ToString(),
+                                        sick = reader["sick"].ToString(),
+                                        employment_type = reader["employment_type"].ToString(),
+                                        start_date = (DateTime)reader["start_date"],
+                                        position = reader["pos_name"].ToString(),
+                                        isCompleteRecord = '1'
+                                    };
+                                }
+
+                                string leaveBalancesDetailsStr = $@"
+                                <div>
+                                     <h4 style = 'display: inline'>Sick Leave Balance:</h4>
+                                     <span> {empDetails.sick} </span>
+                                </div>
+                            ";
+                                // set appropriate leave balance details based on employment type
+                                if (empDetails.employment_type == "Contract")
+                                {
+                                    // is employee in first 11 months of contract?
+                                    DateTime startDate = empDetails.start_date;
+                                    DateTime elevenMonthsFromStartDate = startDate.AddMonths(11);
+
+                                    if (DateTime.Compare(DateTime.Today, elevenMonthsFromStartDate) < 0)
+                                        // display personal 
+                                        leaveBalancesDetailsStr += $@"
+                                        <div>
+                                            <h4 style='display: inline'>Personal Leave Balance:</h4>
+                                            <span>{empDetails.personal}</span>
+                                        </div>
+                                     ";
+                                    else
+                                    {
+                                        // display vacation 
+                                        leaveBalancesDetailsStr += $@"
+                                        <div>
+                                            <h4 style='display: inline'>Vacation Leave Balance:</h4>
+                                            <span>{empDetails.vacation}</span>
+                                        </div>
+                                     ";
+                                    }
+
+                                }
+                                else if (empDetails.employment_type == "Public Service")
+                                {
+                                    // public service employees- show casual and vacation
+                                    leaveBalancesDetailsStr += $@"
+                                        <div>
+                                            <h4 style='display: inline'>Casual Leave Balance:</h4>
+                                            <span>{empDetails.casual}</span>
+                                        </div>
+                                        <div>
+                                            <h4 style='display: inline'>Vacation Leave Balance:</h4>
+                                            <span>{empDetails.vacation}</span>
+                                        </div>
+                                     ";
+                                }
+
+                                empDetails.leave_balances = leaveBalancesDetailsStr;
+                            }     
                         }
                     }
                 }
@@ -366,11 +423,10 @@ namespace HR_LEAVEv2.HR
 
             if (empDetails == null)
             {
-                empDetails = null;
                 try
                 {
                     string sql = $@"
-                        SELECT e.employee_id, e.ihris_id, e.first_name + ' ' + e.last_name as 'Name', e.email,e.vacation,e.personal, e.casual, e.sick
+                        SELECT e.employee_id, e.ihris_id, e.first_name + ' ' + e.last_name as 'Name', e.email
                         FROM [dbo].[employee] e
                         WHERE e.employee_id = {emp_id};
                     ";
@@ -390,10 +446,6 @@ namespace HR_LEAVEv2.HR
                                         ihris_id = reader["ihris_id"].ToString(),
                                         name = reader["name"].ToString(),
                                         email = reader["email"].ToString(),
-                                        vacation = reader["vacation"].ToString(),
-                                        personal = reader["personal"].ToString(),
-                                        casual = reader["casual"].ToString(),
-                                        sick = reader["sick"].ToString(),
                                         isCompleteRecord = '0'
                                     };
                                 }

--- a/HR_LEAVEv2/Supervisor/MyEmployees.aspx
+++ b/HR_LEAVEv2/Supervisor/MyEmployees.aspx
@@ -249,35 +249,11 @@
                                 </div>
                             </div>
 
-                            <div id="errorPanel" class="alert alert-info" style="margin: 5px 0px; display: inline-block; font-size: 0.90em">
-                                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                                <span>Employment Type and employee position info could not be loaded</span>
-                            </div>
-
                             <hr style="width: 45%;" />
 
                             <h3>Leave Balances</h3>
 
-                            <div>
-                                <h4 style="display: inline">Vacation Leave Balance:</h4>
-                                <span id="vacationDetails"></span>
-                            </div>
-
-                            <div>
-                                <h4 style="display: inline">Personal Leave Balance:</h4>
-                                <span id="personalDetails"></span>
-                            </div>
-
-                            <div>
-                                <h4 style="display: inline">Casual Leave Balance:</h4>
-                                <span id="casualDetails"></span>
-                            </div>
-
-                            <div>
-                                <h4 style="display: inline">Sick Leave Balance:</h4>
-                                <span id="sickDetails"></span>
-                            </div>
-
+                            <div id="leaveBalancesDetails"></div>
                         </div>
 
                         <div class="modal-footer">
@@ -347,20 +323,9 @@
             $('#empIdDetails').text(data.emp_id);
             $('#ihrisIdDetails').text(data.ihris_id);
             $('#emailDetails').text(data.email);
-            $('#vacationDetails').text(data.vacation);
-            $('#personalDetails').text(data.personal);
-            $('#casualDetails').text(data.casual);
-            $('#sickDetails').text(data.sick);
-            if (data.isCompleteRecord == '1') {
-                $('#errorPanel').hide();
-                $('#positionDetails').show();
-
-                $('#empTypeDetails').text(data.employment_type);
-                $('#empPositionDetails').text(data.position);
-            } else {
-                $('#positionDetails').hide();
-                $('#errorPanel').show();
-            }
+            $('#empPositionDetails').text(data.position);
+            $('#empTypeDetails').text(data.employment_type);
+            $('#leaveBalancesDetails').html(data.leave_balances);
 
         }
     </script>


### PR DESCRIPTION
1. Only relevant leave balances are now shown
2. Error message is shown to let user know leave balances could not be loaded if the employee details trying to be viewed belong to an inactive employee